### PR TITLE
maint: update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,40 @@
 repos:
 
 - repo: https://github.com/psf/black
-  rev: 23.7.0
+  rev: 26.3.1
   hooks:
   - id: black
     args: [src]
 
 - repo: https://github.com/adamchainz/blacken-docs
-  rev: 1.15.0
+  rev: 1.20.0
   hooks:
   - id: blacken-docs
     additional_dependencies: [black==23.7.0]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.12.0
+  rev: 8.0.1
   hooks:
   - id: isort
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 7.3.0
   hooks:
   - id: flake8
     args: [src]
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.5
+  rev: v2.4.2
   hooks:
   - id: codespell
 
 - repo: https://github.com/yoheimuta/protolint
-  rev: v0.45.0
+  rev: v0.56.4
   hooks:
   - id: protolint
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v6.0.0
   hooks:
   - id: check-merge-conflict
   - id: debug-statements


### PR DESCRIPTION
As title says.

Previous versions have reported false positive issues during linting analysis.